### PR TITLE
🌐 Add LocaleText DTO for multilingual support

### DIFF
--- a/src/common/dto/locale-text.dto.ts
+++ b/src/common/dto/locale-text.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class LocaleText {
+  @ApiProperty({ example: '한국어 텍스트' })
+  ko: string
+
+  @ApiProperty({ example: 'English text' })
+  en: string
+
+  @ApiProperty({ example: '日本語テキスト' })
+  jp: string
+}


### PR DESCRIPTION
## Summary
- Added `LocaleText` DTO to support multilingual fields (ko/en/jp)
- Annotated with Swagger decorators for API documentation

## Changes
- Created `src/common/dto/locale-text.dto.ts`
- Defined class fields: `ko`, `en`, `jp`
- Included `@ApiProperty()` with example values for each

## Notes
- Initially, the file was added without class content
- This PR properly defines the `LocaleText` DTO
- Will be reused across album, news, and video modules
- No breaking changes
