### PR TITLE
🔐 feat: Add API Key + IP whitelist authentication filter

### DIFF
--- a/src/whitelist-ip/api-key-ip-auth.guard.ts
+++ b/src/whitelist-ip/api-key-ip-auth.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { WhitelistIpService } from './whitelist-ip.service';
+import APIException from 'src/common/dto/APIException.dto';
+
+@Injectable()
+export class ApiKeyAndIpAuthGuard implements CanActivate {
+  constructor(private readonly whitelistIpService: WhitelistIpService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req: any = context.switchToHttp().getRequest();
+    const apiKey = req.headers['x-api-key'] || req.headers['X-API-KEY'];
+    const ip = req.ip || req.connection?.remoteAddress;
+
+    if (!apiKey || apiKey !== process.env.ADMIN_API_KEY) {
+      throw new APIException(HttpStatus.UNAUTHORIZED, 'Invalid API Key');
+    }
+
+    const allowed = await this.whitelistIpService.isWhitelisted(ip);
+    if (!allowed) {
+      throw new APIException(HttpStatus.FORBIDDEN, 'Unauthorized IP address');
+    }
+
+    return true;
+  }
+}

--- a/src/whitelist-ip/schemas/whitelist-ip.schema.ts
+++ b/src/whitelist-ip/schemas/whitelist-ip.schema.ts
@@ -1,0 +1,14 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+@Schema({ collection: 'whitelistIp', timestamps: true })
+export class WhitelistIp {
+  @Prop({ required: true, unique: true })
+  ip: string;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type WhitelistIpDocument = WhitelistIp & Document;
+export const WhitelistIpSchema = SchemaFactory.createForClass(WhitelistIp);

--- a/src/whitelist-ip/whitelist-ip.module.ts
+++ b/src/whitelist-ip/whitelist-ip.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { WhitelistIpService } from './whitelist-ip.service';
+import { WhitelistIp, WhitelistIpSchema } from './schemas/whitelist-ip.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: WhitelistIp.name, schema: WhitelistIpSchema }]),
+  ],
+  providers: [WhitelistIpService],
+  exports: [WhitelistIpService],
+})
+export class WhitelistIpModule {}

--- a/src/whitelist-ip/whitelist-ip.service.ts
+++ b/src/whitelist-ip/whitelist-ip.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { WhitelistIp, WhitelistIpDocument } from './schemas/whitelist-ip.schema';
+
+@Injectable()
+export class WhitelistIpService {
+  constructor(
+    @InjectModel(WhitelistIp.name)
+    private readonly whitelistIpModel: Model<WhitelistIpDocument>,
+  ) {}
+
+  async isWhitelisted(ip: string): Promise<boolean> {
+    const found = await this.whitelistIpModel.findOne({ ip });
+    return !!found;
+  }
+
+  async addIp(ip: string): Promise<WhitelistIpDocument> {
+    return this.whitelistIpModel.create({ ip });
+  }
+
+  async removeIp(ip: string): Promise<void> {
+    await this.whitelistIpModel.deleteOne({ ip });
+  }
+
+  async getAll(): Promise<WhitelistIpDocument[]> {
+    return this.whitelistIpModel.find().sort({ createdAt: -1 });
+  }
+}


### PR DESCRIPTION
## Description
- Introduced API Key + IP-based authentication guard
- IP addresses are managed via a MongoDB whitelist collection
- Includes:
  - `WhitelistIpModule`
  - `WhitelistIpSchema`
  - `WhitelistIpService`
  - `ApiKeyAndIpAuthGuard`
- Throws 401 for invalid API key
- Throws 403 for non-whitelisted IPs

## Notes
- Future integration with Discord bot planned for IP management
- Not applied globally yet — used selectively via `@UseGuards()` decorator
